### PR TITLE
Work on issue #25467052: System lagged out

### DIFF
--- a/src/com/android/providers/calendar/CalendarProvider2.java
+++ b/src/com/android/providers/calendar/CalendarProvider2.java
@@ -4584,6 +4584,7 @@ public class CalendarProvider2 extends SQLiteContentProvider implements OnAccoun
     private void doSendUpdateNotification() {
         Intent intent = new Intent(Intent.ACTION_PROVIDER_CHANGED,
                 CalendarContract.CONTENT_URI);
+        intent.addFlags(Intent.FLAG_RECEIVER_REPLACE_PENDING);
         if (Log.isLoggable(TAG, Log.INFO)) {
             Log.i(TAG, "Sending notification intent: " + intent);
         }


### PR DESCRIPTION
Use REPLACE_PENDING when sending change broadcasts for the calendar
provider, so they don't cause backup in the queue.

Change-Id: Iab92c4a48a3e1ff085246e5ebc16fefae927133b